### PR TITLE
bugfix job topic builder: use jobID for REQUEST type

### DIFF
--- a/src/aws_iot_jobs_topics.c
+++ b/src/aws_iot_jobs_topics.c
@@ -115,7 +115,7 @@ int aws_iot_jobs_get_api_topic(char *buffer, size_t bufferSize,
 
 	const char *suffix = _get_suffix_for_topic_type(replyType);
 
-	if (requireJobId || (topicType == JOB_WILDCARD_TOPIC && jobId != NULL)) {
+	if (jobId != NULL) {
 		return snprintf(buffer, bufferSize, BASE_THINGS_TOPIC "%s/jobs/%s/%s%s", thingName, jobId, operation, suffix);
 	} else if (topicType == JOB_WILDCARD_TOPIC) {
 		return snprintf(buffer, bufferSize, BASE_THINGS_TOPIC "%s/jobs/#", thingName);


### PR DESCRIPTION
Fix for building the topic name:
$aws/things/ThingName/$next/get/accepted
jobId is `$next` but it's not require and topicType is JOB_GET_PENDING_TOPIC (and not JOB_WILDCARD_TOPIC)

Signed-off-by: Clément Marrast <clement.marrast@zodiac.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
